### PR TITLE
Restart from scratch

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,3 +2,7 @@
 #+AUTHOR: Ashton Wiersdorf
 
 This is a compiler for a typed lambda calculus targeting the x86 architecture. Includes a parser, type checker, and compiler.
+
+See [[file:project.org][project.org]] for more information about the current status of this compiler.
+
+The main entry point is in [[file:compiler.rkt][compiler.rkt]]; you can see examples of how to run it under the "Tests" header.

--- a/compiler.rkt
+++ b/compiler.rkt
@@ -25,14 +25,34 @@
     [(node/immediate _ num)
      (emit (movq (immediate num) (reg 'ret-val)))]
 
+    [(node/prim _ name arity args)
+     (compile-primitive stack env name arity args)]
+
     ))
+
+(define (compile-primitive stack env name arity args)
+  (match name
+    ['add1
+     (compile-ast (car args) stack env)
+     (emit (addq (immediate 1) (reg 'ret-val)))]
+    ['zero?
+     (compile-ast (car args) stack env)
+     (emit (num-equals (immediate 0) (reg 'ret-val)))
+     ]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 [module+ test
+  ;; Compile constants
   (check-equal? (crc 42) "42")
-  (check-equal? (crc 45) "45")]
+  (check-equal? (crc 45) "45")
+
+  ;; Primitive operators
+  (check-equal? (crc '(add1 5)) "6")
+  (check-equal? (crc '(zero? 5)) "#f")
+  (check-equal? (crc '(zero? 0)) "#t")
+  ]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Testing utilities
@@ -42,7 +62,6 @@
   (compile expr)
   (system "gcc compiler-output.s driver.c")
   (with-output-to-string (lambda () (system "./a.out"))))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Output routines

--- a/compiler.rkt
+++ b/compiler.rkt
@@ -21,6 +21,9 @@
   (emit (ret)))
 
 (define (compile-ast ast stack env)
+  ;; Primary copmiler dispatch: each AST node is matched here and
+  ;; either compiled inline or compiled separately by the respective
+  ;; routines
   (match ast
     [(node/immediate _ num)
      (emit (movq (immediate num) (reg 'ret-val)))]
@@ -92,7 +95,7 @@
 (define (emit thing) (emit-string thing))
 
 (define (global-prelude [emitter emit-string])
-  (emitter ".text
+  (emitter "	.text
 	.p2align 4,,15
 	.globl _scheme_entry
 _scheme_entry:"))

--- a/compiler.rkt
+++ b/compiler.rkt
@@ -1,5 +1,4 @@
 #lang racket
-;(require racket/match racket/pretty)
 (require "ast.rkt")
 (require "type_checker.rkt")
 (require "x86_asm.rkt")
@@ -7,260 +6,59 @@
 (module+ test
   (require rackunit))
 
-(provide compile)
-
+;; Constants
 (define asm-file "compiler-output.s")
 
+(define-syntax-rule (c expr)
+  ;; Macro to make this easier
+  (compile (quote expr)))
+
 (define (compile expr)
+  ;; Parse, and then compile the resulting expression
   (delete-file asm-file)
   (global-prelude)
-  (compile-expr expr '() (- wordsize))
-  (emit-string (ret)))
+  (compile-ast (parse expr) 0 '())
+  (emit (ret)))
 
-(define (compile-expr expr env stack-bottom [emit emit-string])
-  (match expr
-
+(define (compile-ast ast stack env)
+  (match ast
     [(node/immediate _ num)
      (emit (movq (immediate num) (reg 'ret-val)))]
 
-    [(node/prim type 'cons 2 args)
-     (emit (label (gensym 'start_cons)))
-     (compile-expr (cadr args) env stack-bottom emit)                ; compile the cdr
-     (let-values ([(the-car new-stack) (push-stack (reg 'ret-val) stack-bottom emit)])
-       (compile-expr (car args) env (- new-stack wordsize) emit)     ; compile the car
-       (emit (movq (reg 'ret-val) (heap 0)))                         ; copy car to free pointer
-       (emit (movq the-car (reg 'ret-val)))                          ; copy the cdr to next area
-       (emit (movq (reg 'ret-val) (heap wordsize)))
-       (emit (movq (reg 'heap) (reg 'ret-val)))
-       (emit (orq (raw-immediate 1) (reg 'ret-val)))                 ; tag our return value as pointing to a pair
-       (emit (addq (raw-immediate (* 2 wordsize)) (reg 'heap)))
-       (emit (label (gensym 'end_cons))))]
-
-    [(node/prim type name 2 args)
-     ;; These are in a funky order because `-` is not communative
-     (compile-expr (cadr args) env stack-bottom emit)
-     (let-values ([(arg1 new-stack) (push-stack (reg 'ret-val) stack-bottom emit)])
-       (compile-expr (car args) env new-stack emit)
-       (emit ((prim-bin-op name) arg1 (reg 'ret-val))))]
-
-    [(node/if type condition t-case f-case)
-     (let ([l0 (gensym 'false_branch)]
-           [l1 (gensym 'cond_end)])
-       (compile-expr condition env stack-bottom emit)
-       (emit (cmpq (immediate #f) (reg 'ret-val)))
-       (emit (je l0))                   ; jump to the false branch
-       (compile-expr t-case env stack-bottom emit)
-       (emit (jmp l1))
-       (emit (label l0))
-       (compile-expr f-case env stack-bottom emit)
-       (emit (label l1)))]
-
-    [(node/app type (node/var _ func-name) args)                     ; TODO: look up the function arity
-     (emit (label (gensym 'start_app)))
-
-     ;; Save params
-     (for ([param '(param-1 param-2 param-3 param-4)]
-           [idx (in-naturals 0)])
-       (emit (movq (reg param) (stack (- stack-bottom (* wordsize idx))))))
-
-     (let ([new-stack-bottom (- stack-bottom (* wordsize 4))])
-       ;; Move arguments into slots on the stack
-       (for ([arg args]                                                ; I love me some list comprehensions
-             [idx (in-naturals)]
-             [p-idx '(param-1 param-2 param-3 param-4)])
-         (emit (label (gensym (format "arg_~a" idx))))
-         (compile-expr arg env (- new-stack-bottom (* wordsize 5)))        ; FIXME: make this be based off the number of arguments
-         (emit (movq (reg 'ret-val) (stack (- new-stack-bottom (* wordsize idx)))))
-         (emit (label (gensym (format "arg_~a_done" idx)))))
-
-       ;; All arguments computed; move them off the stack and into registers
-       (for ([p-idx '(param-1)] ; param-2 param-3 param-4)]
-             [idx (in-naturals)])
-         (emit (movq (stack (- new-stack-bottom (* wordsize idx))) (reg p-idx))))
-
-       ;; Normalize stack before call: we might have manually allocated
-       ;; some values on the stack, and we want to preserve them
-       #;(emit (addq new-stack-bottom (reg 'stack)))
-       ;; (emit (addq (- new-stack-bottom wordsize) (reg 'stack)))
-
-       ;; Call
-       (emit (call (env/var-info env func-name)))
-
-       ;; Restore old stack
-       #;(emit (subq new-stack-bottom (reg 'stack))))
-;       (emit (subq (- new-stack-bottom wordsize) (reg 'stack))))
-
-     ;; restore params
-     (for ([param '(param-1 param-2 param-3 param-4)]
-           [idx (in-naturals 0)])
-       (emit (movq (stack (- stack-bottom (* wordsize idx))) (reg param))))]
-
-
-    [(node/labels _ lvars body)
-     (compile-labels lvars body env stack-bottom emit)]
-
-    [(node/lambda type params body)
-     (compile-lambda type params body env stack-bottom emit)]
-
-    [(node/let type bindings body)
-     (compile-let type bindings body env stack-bottom emit)]
-
-    [(node/var type name)
-     (emit (movq (if (symbol? (env/var-info env name))               ; If I've got a symbol, it's a register name;
-                     (reg (env/var-info env name))                   ; numbers mean an offset from the current stack
-                     (stack (or (env/var-info env name) (error 'undefined-variable))))
-                 (reg 'ret-val)))]
-
     ))
 
-(define (compile-let type bindings body env stack-bottom [emit emit-string])
-  (if (null? bindings)
-      ;; If no more bindings to compile, compile the let body
-      (compile-expr body env stack-bottom emit)
-      (let ([b (car bindings)])
-        ;; Ok, we've got a binding. Let's compile it's value
-        (compile-expr (node/let-binding-value b) env stack-bottom emit)
-        ;; Now we're going to move that result into the bottom of the stack
-        (emit (movq (reg 'ret-val) (stack stack-bottom)))
-        ;; Recur: compile the rest of the bindings: increment the
-        ;; stack, and extend the env to point to the stack position we
-        ;; just moved the value of this binding's variable to
-        (compile-let type (cdr bindings) body
-                     (env/extend env
-                                 (node/let-binding-variable b)
-                                 stack-bottom)
-                     (- stack-bottom wordsize)
-                     emit))))
-
-(define (compile-labels defs def-body env stack-bottom [emit emit-string])
-  (let ([end-label (fresh-label)])
-    (emit (jmp end-label))
-    (define (compile-labels-loop defs def-body env stack-bottom)
-      (if (null? defs)
-          ;; No more defs? Compile the body where the function calls will be
-          (begin
-            (emit (label end-label))
-            (compile-expr def-body env stack-bottom emit))
-          (match defs
-            [(list (node/lvar _ name params body) rest-defs ...)                       ; Pull out the first binding
-             (let* ([new-label (function-label name)]                                  ; Create a new label for this function
-                    [new-env (for/fold ([new-env (env/extend env name new-label)])     ; Extend the env: map the param to a location on the stack
-                                       ([i (in-naturals)]
-                                        [p params])
-                               (env/extend new-env p (stack 0 (* wordsize i))))])
-               (emit (label new-label))                                                ; Emit the function label
-               ;; Warning: maybe an off-by-one error
-               (compile-expr body new-env stack-bottom emit)                              ; Compile the body of function in this lable
-               (emit (ret))
-               (compile-labels-loop rest-defs def-body new-env stack-bottom))])))
-
-    (compile-labels-loop defs def-body env stack-bottom)))
-
-(define (compile-lambda type params body env stack-bottom [emit emit-string])
-  (error "Darn. This is a hard problem."))
-
-(define (push-stack var-loc stack-bottom [emit emit-string])
-  ;; Emit code needed to push a variable onto the stack, and return
-  ;; the new stack bottom and the location the variable was at
-
-  ;; We assume stack-bottom is writeable; that means the caller will
-  ;; have to ensure we never call 0(%esp), because that would
-  ;; overwrite the return value. We place this burden on the caller so
-  ;; that we can call this function sequentially without wasting space
-  ;; on the stack.
-  (emit (movq var-loc (stack stack-bottom)))
-  (values (stack stack-bottom) (- stack-bottom wordsize)))
-
-(define (env/new) '())
-
-;; Returns the info associated with a variable from the environment
-(define (env/var-info env var)
-  (match env
-    [(list) #f]                   ; Not in env
-    [(cons (cons v t) rst)
-     #:when (eq? v var)
-     t]
-    [(cons _ rst) (env/var-info rst var)]))
-
-;; Extend a env with a value
-(define (env/extend env var info)
-  (cons (cons var info) env))
-
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 [module+ test
-  (let ([ctx (env/extend (env/new) 'foo 'integer)])
-    (check-eq? (env/var-info ctx 'foo) 'integer)
-    (check-eq? (env/var-info (env/extend ctx 'bar 'string) 'foo) 'integer)
-    (check-eq? (env/var-info (env/extend ctx 'bar 'string) 'bar) 'string))]
+  (check-equal? (crc 42) "42")
+  (check-equal? (crc 45) "45")]
 
-(define (foreach-shortest proc . lists)
-  (if (findf (λ (l) (eq? l '())) lists)
-      (void)
-      (begin
-        (apply proc (map car lists))
-        (apply foreach-shortest (cons proc (map cdr lists))))))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Testing utilities
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define (crc expr)
+  ;; CRC: *C*ompile, *R*un, *C*apture output
+  (compile expr)
+  (system "gcc compiler-output.s driver.c")
+  (with-output-to-string (lambda () (system "./a.out"))))
 
-[module+ test
-  (let ([i 1])
-    (foreach-shortest (λ (a b) (set! i (+ i a b))) '(2 4 8 16) '(32 64))
-    (check-= i 103 0))]
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Output routines
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (write-to-asm thing)
-  (println (list 'emit: thing))
+  #;(println (list 'emit: thing))
   (with-output-to-file asm-file (λ () (if (not (string-suffix? thing ":")) (display "\t") (void)) (displayln thing)) #:exists 'append))
 
 (define (emit-string thing [writer write-to-asm])
   (writer thing))
 
+(define (emit thing) (emit-string thing))
+
 (define (global-prelude [emitter emit-string])
-  (emitter "	.text
-        .p2align 4,,15
+  (emitter ".text
+	.p2align 4,,15
 	.globl _scheme_entry
-_scheme_entry:
-        movq %rdi, %r15
-"))
-
-[module+ test
-  (check-eqv? (global-prelude (λ (x) x)) "	.text
-        .p2align 4,,15
-	.globl _scheme_entry
-_scheme_entry:
-        movq %rdi, %r15
-")]
-
-;; Torture-test
-
-[module+ torture-test
-  ;; This should be (120 . 5)
-  (compile (parse '(labels ((f2 (code (n) (if (= n 1) n (* n (app f2 (- n 1))))))) (cons (let ((x 4)) (app f2 (+ x 1))) 5))))
-  (compile (parse '(labels ((f2 (code (n) (if (= n 1) n (* n (app f2 (- n 1))))))) (cons (let ((x 5)) (app f2 x)) 5))))
-
-  (compile (parse '(labels ((f1 (code (n) (if (= n 0) 1 (* n (app f1 (- n 1))))))
-                            (f2 (code (n) (if (= n 1) n (* n (app f2 (- n 1))))))
-                            (f3 (code (n acc) (if (= n 0) acc (app f3 (- n 1) (* acc n)))))
-                            (f4 (code (acc n) (if (= 0 n) acc (app f4 (* acc n) (- n 1)))))
-                            (f5 (code (n) (app f3 n 1))))
-
-                           (let ((r-f1 (app f1 5))
-                                 (r-f2 (app f2 5))
-                                 (r-f3 (app f3 5 1))
-                                 (r-f4 (app f4 1 5))
-                                 (r-f5 (app f5 5)))
-                             (cons (cons (app f5 (- (app f5 3) 1)) (cons (cons r-f1 r-f2) r-f3)) (cons (* 12 (+ 2 8)) (cons r-f4 r-f5)))))))
-
-  ;; This should be ((120 . ((120 . 120) . 120)) . (120 . (120 . (120 . 120))))
-  (compile (parse '(labels ((f1 (code (n) (if (= n 0) 1 (* n (app f1 (- n 1))))))
-                   (f2 (code (n) (if (= n 1) n (* n (app f2 (- n 1))))))
-                   (f3 (code (n acc) (if (= n 0) acc (app f3 (- n 1) (* acc n)))))
-                   (f4 (code (acc n) (if (= 0 n) acc (app f4 (* acc n) (- n 1)))))
-                   (f5 (code (n) (app f3 n 1))))
-
-                  (let ((r-f1 (app f1 5))
-                        (r-f2 (app f2 5))
-                        (r-f3 (app f3 5 1))
-                        (r-f4 (app f4 1 5))
-                        (r-f5 (app f5 5)))
-                    (cons (cons (app f5 (- (app f5 3) 1)) (cons (cons r-f1 r-f2) r-f3)) (cons (* 12 (+ 2 8)) (cons r-f4 (cons
-                                                                                                                         (let ((x 4)) (app f2 (+ x 1)))
-                                                                                                                         r-f5))))))))
-  
-  ]
+_scheme_entry:"))

--- a/driver.c
+++ b/driver.c
@@ -27,19 +27,15 @@
 size_t scheme_entry(size_t *heap);
 void format_val(size_t val);
 
-void beep() {
-  printf("beep\n");
-}
-
 int main(int argc, char** argv) {
   size_t *heap = malloc(heap_size);
-  printf("[INFO] heap addr: %p\n", heap);
+  /* printf("[INFO] heap addr: %p\n", heap); */
   size_t val = scheme_entry(heap);
 
-  printf("\n>>>LAMBDA x86 FINISHED<<<\n\n");
+  /* printf("\n>>>LAMBDA x86 FINISHED<<<\n\n"); */
 
   format_val(val);
-  printf("\n");
+  /* printf("\n"); */
   return 0;
 }
 

--- a/project.org
+++ b/project.org
@@ -1,4 +1,5 @@
 #+TITLE: Lambda-x86 Project Notes
+#+AUTHOR: Ashton Wiersdorf
 
 I've decided to build a quick-and-dirty compiler following _An Incremental Approach to Compiler Construction_ by Abdulaziz Ghuloum. I can build a bigger compiler later.
 
@@ -6,46 +7,12 @@ I've also decided to ditch continuation-passing style for this first draft. I'll
 
 I wanted to use stack-based parameter passing, but I gave up and am just using four registers instead. (I've forgotten a bit about how the stack works and I just wanted to move on.)
 
+But using registers for argument passing turned out to be rather complicated, so now I'm back to using the stack.
+
+The type checker/inference engine works alright, but I'm not using it at all right now. It uses bidirectional type checking with inference; I'll probably rewrite this to do a full Hindley-Milner type checking/inference engine later.
+
 * Tasks
-** TODO How could I use ~push~ and ~pop~?                       :enhancement:
-I'd like to be able to use x86's capacities to improve generated code
-performance. I might have to push this off and just have a static
-stack pointer
-** TODO Rewrite compiler to not use ~push~ and ~pop~ commands
-Turns out there's a new bug with ~let~ that will make using ~push~ and
-~pop~ difficult: I'm manually rewriting the stack pointer to get
-function calls to work, but that messes up my variable references
-
-** DONE Fix up parser to handle booleans
-   CLOSED: [2020-03-26 Thu 22:06]
-   :LOGBOOK:
-   - State "DONE"       from "TODO"       [2020-03-26 Thu 22:06]
-   :END:
-** DONE Finish parsing ~let~ nodes
-   CLOSED: [2020-03-27 Fri 20:30]
-   :LOGBOOK:
-   - State "DONE"       from "TODO"       [2020-03-27 Fri 20:30]
-   :END:
-** DONE Fix (cons (funcall) (any)) bug                                  :bug:
-   CLOSED: [2020-04-23 Thu 21:38]
-   :LOGBOOK:
-   - State "DONE"       from "TODO"       [2020-04-23 Thu 21:38]
-   :END:
-Trying to run something like this:
-
-#+BEGIN_SRC racket
-
-  (compile (parse '(labels ((f (code (n) (if (= n 0) 1 (* n (app f (- n 1)))))))
-                           (cons (app f 5) 6))))
-
-#+END_SRC
-
-Computes the factorial value correctly, but gives something that looks like a pointer for the ~cdr~.
-
 * Tasks for later
-** TODO Should I have a ~node/app~ for regular function calls, and a ~node/lapp~ for direct lambda calls?
-I think so. It's kind of like differentiating between ~kapp~ and regular ~app~.
-** TODO Write a tortue test for the compiler thus far
 ** TODO Fix up type checker                                     :enhancement:
 I wonder if there's a way to use the type information to make my assembler more efficient. (I bet there is; I'll leave that for an enhancement.)
 ** TODO Use type information to improve instruction choice      :enhancement:
@@ -101,48 +68,4 @@ _main:                                  ## @main
 .subsections_via_symbols
 
 #+END_SRC
-* Notebook
-** DONE Recursion bug
-   CLOSED: [2020-04-03 Fri 00:05]
-   :LOGBOOK:
-   - State "DONE"       from              [2020-04-03 Fri 00:05]
-   :END:
 
-These break:
-
-#+BEGIN_SRC racket
-(compile (parse '(labels ((f0 (code (a) (+ a 1))) (f1 (code (b) (if (= b 0) (app f0 b) (app f1 (+ b 1)))))) (app f1 1))))
-
-(compile (parse '(labels ((f0 (code (a) (+ a 1))) (f1 (code (b) (if (= b 0) (app f0 b) (let ((c (+ b 1))) (app f1 c)))))) (app f1 1))))
-#+END_SRC
-
-But these don't:
-
-#+BEGIN_SRC racket
-(compile (parse '(labels ((f0 (code (a) (+ a 1))) (f1 (code (b) (if (= b 0) (app f0 b) (let ((c (+ b 1))) (+ c 1)))))) (app f1 1))))
-
-(compile (parse '(labels ((f0 (code (a) (+ a 1))) (f1 (code (b) (if (= b 0) (app f0 b) (app f0 7))))) (app f1 1))))
-
-(compile (parse '(labels ((f0 (code (a) (+ a 1)))) (let ((a 1)) (app f0 (+ a 1))))))
-#+END_SRC
-
-Oh, oops. That's because the breaking ones are actually recursing infinitely.
-** Multi-value recursion bug
-
-This works:
-
-#+BEGIN_SRC racket
-
-  (compile (parse '(labels ((factorial (code (n) (if (= n 0) 1 (* n (app factorial (- n 1))))))) (app factorial 5))))
-
-#+END_SRC
-
-But this doesn't:
-
-#+BEGIN_SRC racket
-
-  (compile (parse '(labels ((factorial (code (n acc) (if (= n 0) acc (app factorial (- n 1) (* acc n)))))) (app factorial 5 1))))
-
-#+END_SRC
-
-I think it's because I'm not using my stack right: instead of writing values to absolute places on the stack, I should try to use push and pop. Else, check my useage of the stack. See page 276 in the textbook for a detailed description.

--- a/project.org
+++ b/project.org
@@ -13,6 +13,7 @@ The type checker/inference engine works alright, but I'm not using it at all rig
 
 * Tasks
 * Tasks for later
+** TODO Check the number of arguments to a function at compile time
 ** TODO Fix up type checker                                     :enhancement:
 I wonder if there's a way to use the type information to make my assembler more efficient. (I bet there is; I'll leave that for an enhancement.)
 ** TODO Use type information to improve instruction choice      :enhancement:

--- a/project.org_archive
+++ b/project.org_archive
@@ -1,0 +1,182 @@
+#    -*- mode: org -*-
+
+
+Archived entries from file /Users/ashton/Wiersdorf/lambda-x86/project.org
+
+
+* TODO How could I use ~push~ and ~pop~?                                               :enhancement:
+  :PROPERTIES:
+  :ARCHIVE_TIME: 2020-05-12 Tue 22:54
+  :ARCHIVE_FILE: ~/Wiersdorf/lambda-x86/project.org
+  :ARCHIVE_OLPATH: Tasks
+  :ARCHIVE_CATEGORY: project
+  :ARCHIVE_TODO: TODO
+  :END:
+I'd like to be able to use x86's capacities to improve generated code
+performance. I might have to push this off and just have a static
+stack pointer
+
+Archived entries from file /Users/ashton/Wiersdorf/lambda-x86/project.org
+
+
+* TODO Rewrite compiler to not use ~push~ and ~pop~ commands
+  :PROPERTIES:
+  :ARCHIVE_TIME: 2020-05-12 Tue 22:54
+  :ARCHIVE_FILE: ~/Wiersdorf/lambda-x86/project.org
+  :ARCHIVE_OLPATH: Tasks
+  :ARCHIVE_CATEGORY: project
+  :ARCHIVE_TODO: TODO
+  :END:
+Turns out there's a new bug with ~let~ that will make using ~push~ and
+~pop~ difficult: I'm manually rewriting the stack pointer to get
+function calls to work, but that messes up my variable references
+
+
+Archived entries from file /Users/ashton/Wiersdorf/lambda-x86/project.org
+
+
+* DONE Fix up parser to handle booleans
+  CLOSED: [2020-03-26 Thu 22:06]
+  :PROPERTIES:
+  :ARCHIVE_TIME: 2020-05-12 Tue 22:54
+  :ARCHIVE_FILE: ~/Wiersdorf/lambda-x86/project.org
+  :ARCHIVE_OLPATH: Tasks
+  :ARCHIVE_CATEGORY: project
+  :ARCHIVE_TODO: DONE
+  :END:
+  :LOGBOOK:
+  - State "DONE"       from "TODO"       [2020-03-26 Thu 22:06]
+  :END:
+
+Archived entries from file /Users/ashton/Wiersdorf/lambda-x86/project.org
+
+
+* DONE Finish parsing ~let~ nodes
+  CLOSED: [2020-03-27 Fri 20:30]
+  :PROPERTIES:
+  :ARCHIVE_TIME: 2020-05-12 Tue 22:54
+  :ARCHIVE_FILE: ~/Wiersdorf/lambda-x86/project.org
+  :ARCHIVE_OLPATH: Tasks
+  :ARCHIVE_CATEGORY: project
+  :ARCHIVE_TODO: DONE
+  :END:
+  :LOGBOOK:
+  - State "DONE"       from "TODO"       [2020-03-27 Fri 20:30]
+  :END:
+
+Archived entries from file /Users/ashton/Wiersdorf/lambda-x86/project.org
+
+
+* DONE Fix (cons (funcall) (any)) bug                                                          :bug:
+  CLOSED: [2020-04-23 Thu 21:38]
+  :PROPERTIES:
+  :ARCHIVE_TIME: 2020-05-12 Tue 22:54
+  :ARCHIVE_FILE: ~/Wiersdorf/lambda-x86/project.org
+  :ARCHIVE_OLPATH: Tasks
+  :ARCHIVE_CATEGORY: project
+  :ARCHIVE_TODO: DONE
+  :END:
+   :LOGBOOK:
+   - State "DONE"       from "TODO"       [2020-04-23 Thu 21:38]
+   :END:
+Trying to run something like this:
+
+#+BEGIN_SRC racket
+
+  (compile (parse '(labels ((f (code (n) (if (= n 0) 1 (* n (app f (- n 1)))))))
+                           (cons (app f 5) 6))))
+
+#+END_SRC
+
+Computes the factorial value correctly, but gives something that looks like a pointer for the ~cdr~.
+
+
+Archived entries from file /Users/ashton/Wiersdorf/lambda-x86/project.org
+
+
+* TODO Should I have a ~node/app~ for regular function calls, and a ~node/lapp~ for direct lambda calls?
+  :PROPERTIES:
+  :ARCHIVE_TIME: 2020-05-12 Tue 22:54
+  :ARCHIVE_FILE: ~/Wiersdorf/lambda-x86/project.org
+  :ARCHIVE_OLPATH: Tasks for later
+  :ARCHIVE_CATEGORY: project
+  :ARCHIVE_TODO: TODO
+  :END:
+I think so. It's kind of like differentiating between ~kapp~ and regular ~app~.
+
+Archived entries from file /Users/ashton/Wiersdorf/lambda-x86/project.org
+
+
+* TODO Write a tortue test for the compiler thus far
+  :PROPERTIES:
+  :ARCHIVE_TIME: 2020-05-12 Tue 22:54
+  :ARCHIVE_FILE: ~/Wiersdorf/lambda-x86/project.org
+  :ARCHIVE_OLPATH: Tasks for later
+  :ARCHIVE_CATEGORY: project
+  :ARCHIVE_TODO: TODO
+  :END:
+
+Archived entries from file /Users/ashton/Wiersdorf/lambda-x86/project.org
+
+
+* DONE Recursion bug
+  CLOSED: [2020-04-03 Fri 00:05]
+  :PROPERTIES:
+  :ARCHIVE_TIME: 2020-05-12 Tue 22:55
+  :ARCHIVE_FILE: ~/Wiersdorf/lambda-x86/project.org
+  :ARCHIVE_OLPATH: Notebook
+  :ARCHIVE_CATEGORY: project
+  :ARCHIVE_TODO: DONE
+  :END:
+   :LOGBOOK:
+   - State "DONE"       from              [2020-04-03 Fri 00:05]
+   :END:
+
+These break:
+
+#+BEGIN_SRC racket
+(compile (parse '(labels ((f0 (code (a) (+ a 1))) (f1 (code (b) (if (= b 0) (app f0 b) (app f1 (+ b 1)))))) (app f1 1))))
+
+(compile (parse '(labels ((f0 (code (a) (+ a 1))) (f1 (code (b) (if (= b 0) (app f0 b) (let ((c (+ b 1))) (app f1 c)))))) (app f1 1))))
+#+END_SRC
+
+But these don't:
+
+#+BEGIN_SRC racket
+(compile (parse '(labels ((f0 (code (a) (+ a 1))) (f1 (code (b) (if (= b 0) (app f0 b) (let ((c (+ b 1))) (+ c 1)))))) (app f1 1))))
+
+(compile (parse '(labels ((f0 (code (a) (+ a 1))) (f1 (code (b) (if (= b 0) (app f0 b) (app f0 7))))) (app f1 1))))
+
+(compile (parse '(labels ((f0 (code (a) (+ a 1)))) (let ((a 1)) (app f0 (+ a 1))))))
+#+END_SRC
+
+Oh, oops. That's because the breaking ones are actually recursing infinitely.
+
+Archived entries from file /Users/ashton/Wiersdorf/lambda-x86/project.org
+
+
+* Multi-value recursion bug
+  :PROPERTIES:
+  :ARCHIVE_TIME: 2020-05-12 Tue 22:55
+  :ARCHIVE_FILE: ~/Wiersdorf/lambda-x86/project.org
+  :ARCHIVE_OLPATH: Notebook
+  :ARCHIVE_CATEGORY: project
+  :END:
+
+This works:
+
+#+BEGIN_SRC racket
+
+  (compile (parse '(labels ((factorial (code (n) (if (= n 0) 1 (* n (app factorial (- n 1))))))) (app factorial 5))))
+
+#+END_SRC
+
+But this doesn't:
+
+#+BEGIN_SRC racket
+
+  (compile (parse '(labels ((factorial (code (n acc) (if (= n 0) acc (app factorial (- n 1) (* acc n)))))) (app factorial 5 1))))
+
+#+END_SRC
+
+I think it's because I'm not using my stack right: instead of writing values to absolute places on the stack, I should try to use push and pop. Else, check my useage of the stack. See page 276 in the textbook for a detailed description.

--- a/type_checker.rkt
+++ b/type_checker.rkt
@@ -13,6 +13,7 @@
 (define (lambda? sym) (and (member sym '(lambda λ)) (symbol? sym)))
 (define (bin-int-prim? sym) (and (member sym '(+ - * / =)) (symbol? sym)))
 (define (bin-prim? sym) (and (member sym '(cons car cdr)) (symbol? sym)))
+(define (uni-prim? sym) (and (member sym '(add1 zero? empty? null?)) (symbol? sym)))
 
 ;; Convert into CPS and parse
 (define (convert-parse expr)
@@ -64,6 +65,11 @@
      (let* ([cont-node (parse cont)]
             [arg-nodes (map (λ (arg) (parse arg)) args)])
        (node/app 'void cont-node arg-nodes))]
+
+    ;; Unary primitives
+    [`(,(? uni-prim? op) ,x)
+     (let ([x-node (parse x)])
+       (node/prim 'unknown op 1 (list x-node)))]
 
     ;; Integer primitives of two arguments
     [`(,(? bin-int-prim? op) ,x1 ,x2)

--- a/type_checker.rkt
+++ b/type_checker.rkt
@@ -18,7 +18,7 @@
 (define (convert-parse expr)
   (parse (cps expr)))
 
-;; Entry point. We assume that the expression has been alphetized and is in CPS.
+;; Entry point. We're not doing CPS
 (define (parse expr)
   (match expr
     ;; Lambda

--- a/type_checker.rkt
+++ b/type_checker.rkt
@@ -12,8 +12,8 @@
 
 (define (lambda? sym) (and (member sym '(lambda λ)) (symbol? sym)))
 (define (bin-int-prim? sym) (and (member sym '(+ - * / =)) (symbol? sym)))
-(define (bin-prim? sym) (and (member sym '(cons car cdr)) (symbol? sym)))
-(define (uni-prim? sym) (and (member sym '(add1 zero? empty? null?)) (symbol? sym)))
+(define (bin-prim? sym) (and (member sym '(cons)) (symbol? sym)))
+(define (uni-prim? sym) (and (member sym '(car cdr add1 zero? empty? null?)) (symbol? sym)))
 
 ;; Convert into CPS and parse
 (define (convert-parse expr)

--- a/x86_asm.rkt
+++ b/x86_asm.rkt
@@ -55,6 +55,12 @@
 (define (cmpq a b)
   (format "cmpq ~a, ~a" a b))
 
+(define (sete short-reg)
+  (format "sete ~a" short-reg))
+
+(define (salq a b)
+  (format "salq ~a, ~a" a b))
+
 (define (je loc)
   (format "je _~a" loc))
 


### PR DESCRIPTION
Rewrite of the compiler: pass parameters on the stack, don't use `push` and `pop`. Later we'll get to optimizations like those; for now we'll just keep pushing the in-compiler stack counter higher and higher. (Er… I guess it's a negative value, so lower and lower…)